### PR TITLE
Fix icon converting process

### DIFF
--- a/ldoce5viewer/qtgui/resources/icons/icongen.py
+++ b/ldoce5viewer/qtgui/resources/icons/icongen.py
@@ -2,7 +2,7 @@
 
 import sys
 
-import Image, ImageFilter, ImageChops, ImageEnhance, ImageDraw
+from PIL import Image, ImageFilter, ImageChops, ImageEnhance, ImageDraw
 
 
 OFFSET_S = 4
@@ -29,7 +29,7 @@ def make_inset_shadow(alpha):
     m1 = alpha.copy()
     for i in xrange(6):
         m1 = m1.filter(ImageFilter.SMOOTH_MORE)
-    m1 = m1.offset(0, OFFSET_S)
+    m1 = ImageChops.offset(m1, 0, OFFSET_S)
     m1 = ImageChops.subtract(alpha, m1)
     m1b = ImageEnhance.Brightness(m1).enhance(0.35)
 
@@ -48,7 +48,7 @@ def make_highlight(alpha):
     m1 = alpha.copy()
     for i in xrange(2):
         m1 = m1.filter(ImageFilter.SMOOTH_MORE)
-    m1 = m1.offset(0, OFFSET_H)
+    m1 = ImageChops.offset(m1, 0, OFFSET_H)
     m1 = ImageChops.subtract(m1, alpha)
     m1b = ImageEnhance.Brightness(m1).enhance(0.35)
 


### PR DESCRIPTION
python2 icongen.py go-down-48-src.png go-down-48.png
Traceback (most recent call last):
  File "icongen.py", line 94, in <module>
    make(src_path, out_path)
  File "icongen.py", line 82, in make
    (highlight_a, highlight) = make_highlight(srca)
  File "icongen.py", line 51, in make_highlight
    m1 = m1.offset(0, OFFSET_H)
  File "/usr/lib64/python2.7/site-packages/PIL/Image.py", line 1322, in offset
    raise NotImplementedError("offset() has been removed. "